### PR TITLE
fix: key the WDA cache on the XCUITest driver version and refresh stale hits

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33640,10 +33640,14 @@ function shouldCacheWda({
   if (value === "true") return { setUp: true, reason: "ios input is true" };
   return scan(roots) ? { setUp: true, reason: "auto-detected an ios platform in your specs" } : { setUp: false, reason: "no ios platform detected in specs" };
 }
-var CACHE_VERSION = "v1";
-function wdaCacheKey(xcodeVersion, platform2 = import_os4.default.platform()) {
+var CACHE_VERSION = "v2";
+function wdaCacheKey(xcodeVersion, driverVersion, platform2 = import_os4.default.platform()) {
+  const dv = (driverVersion || "unknown").trim().replace(/\s+/g, "-");
+  return `${wdaCacheKeyPrefix(xcodeVersion, platform2)}${dv}`;
+}
+function wdaCacheKeyPrefix(xcodeVersion, platform2 = import_os4.default.platform()) {
   const xc = (xcodeVersion || "unknown").trim().replace(/\s+/g, "-");
-  return `dd-wda-${CACHE_VERSION}-${platform2}-${xc}`;
+  return `dd-wda-${CACHE_VERSION}-${platform2}-${xc}-xcuitest-`;
 }
 function detectXcodeVersion(run = (c) => (0, import_child_process.execSync)(c).toString()) {
   try {
@@ -33652,17 +33656,28 @@ function detectXcodeVersion(run = (c) => (0, import_child_process.execSync)(c).t
     return "unknown";
   }
 }
+function detectXcuitestDriverVersion(run = (c) => (0, import_child_process.execSync)(c).toString()) {
+  try {
+    return run("npm view appium-xcuitest-driver version").trim() || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 async function restoreWdaCache({
   derivedDataPath,
   xcodeVersion,
+  driverVersion,
   deps
 }) {
-  const key = wdaCacheKey(xcodeVersion);
+  const key = wdaCacheKey(xcodeVersion, driverVersion);
+  const prefix2 = wdaCacheKeyPrefix(xcodeVersion);
   try {
-    const restoredKey = await deps.restoreCache([derivedDataPath], key);
+    const restoredKey = await deps.restoreCache([derivedDataPath], key, [
+      prefix2
+    ]);
     const exactHit = restoredKey === key;
     deps.info(
-      exactHit ? `Restored the WebDriverAgent build cache (${key}); the WDA build will be incremental.` : `No WebDriverAgent build cache yet (key ${key}); the first run compiles WDA (~10 min) and caches it.`
+      exactHit ? `Restored the WebDriverAgent build cache (${key}); the WDA build will be incremental.` : restoredKey ? `Restored an older WebDriverAgent build (${restoredKey}); the build warms from it and is re-cached as ${key}.` : `No WebDriverAgent build cache yet (key ${key}); the first run compiles WDA (~10 min) and caches it.`
     );
     return { key, exactHit };
   } catch (error2) {
@@ -73425,6 +73440,7 @@ async function main() {
       const { key, exactHit } = await restoreWdaCache({
         derivedDataPath,
         xcodeVersion: detectXcodeVersion(),
+        driverVersion: detectXcuitestDriverVersion(),
         deps: wdaDeps
       });
       wdaCache = { derivedDataPath, key, exactHit, deps: wdaDeps };

--- a/dist/index.js
+++ b/dist/index.js
@@ -33641,13 +33641,14 @@ function shouldCacheWda({
   return scan(roots) ? { setUp: true, reason: "auto-detected an ios platform in your specs" } : { setUp: false, reason: "no ios platform detected in specs" };
 }
 var CACHE_VERSION = "v2";
+function sanitizeKeySegment(value) {
+  return (value || "unknown").trim().replace(/[^A-Za-z0-9._-]+/g, "-") || "unknown";
+}
 function wdaCacheKey(xcodeVersion, driverVersion, platform2 = import_os4.default.platform()) {
-  const dv = (driverVersion || "unknown").trim().replace(/\s+/g, "-");
-  return `${wdaCacheKeyPrefix(xcodeVersion, platform2)}${dv}`;
+  return `${wdaCacheKeyPrefix(xcodeVersion, platform2)}${sanitizeKeySegment(driverVersion)}`;
 }
 function wdaCacheKeyPrefix(xcodeVersion, platform2 = import_os4.default.platform()) {
-  const xc = (xcodeVersion || "unknown").trim().replace(/\s+/g, "-");
-  return `dd-wda-${CACHE_VERSION}-${platform2}-${xc}-xcuitest-`;
+  return `dd-wda-${CACHE_VERSION}-${platform2}-${sanitizeKeySegment(xcodeVersion)}-xcuitest-`;
 }
 function detectXcodeVersion(run = (c) => (0, import_child_process.execSync)(c).toString()) {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { shouldSetUpAndroid, enableLinuxKvm } from "./androidSetup.ts";
 import {
   shouldCacheWda,
   detectXcodeVersion,
+  detectXcuitestDriverVersion,
   restoreWdaCache,
   saveWdaCache,
   type WdaCacheDeps,
@@ -151,6 +152,7 @@ async function main(): Promise<void> {
       const { key, exactHit } = await restoreWdaCache({
         derivedDataPath,
         xcodeVersion: detectXcodeVersion(),
+        driverVersion: detectXcuitestDriverVersion(),
         deps: wdaDeps,
       });
       wdaCache = { derivedDataPath, key, exactHit, deps: wdaDeps };

--- a/src/iosSetup.test.ts
+++ b/src/iosSetup.test.ts
@@ -8,7 +8,9 @@ import {
   scanForIos,
   shouldCacheWda,
   wdaCacheKey,
+  wdaCacheKeyPrefix,
   detectXcodeVersion,
+  detectXcuitestDriverVersion,
   restoreWdaCache,
   saveWdaCache,
   type WdaCacheDeps,
@@ -99,12 +101,21 @@ test("shouldCacheWda: true always caches on macOS; auto scans", () => {
   );
 });
 
-test("wdaCacheKey folds the Xcode version into a stable key", () => {
+test("wdaCacheKey folds the Xcode and XCUITest driver versions into a stable key", () => {
   assert.equal(
-    wdaCacheKey("Xcode 26.5", "darwin"),
-    "dd-wda-v1-darwin-Xcode-26.5"
+    wdaCacheKey("Xcode 26.5", "9.2.1", "darwin"),
+    "dd-wda-v2-darwin-Xcode-26.5-xcuitest-9.2.1"
   );
-  assert.equal(wdaCacheKey("", "darwin"), "dd-wda-v1-darwin-unknown");
+  assert.equal(
+    wdaCacheKey("", "", "darwin"),
+    "dd-wda-v2-darwin-unknown-xcuitest-unknown"
+  );
+});
+
+test("wdaCacheKeyPrefix is the key minus the driver version, for restore-keys fallback", () => {
+  const prefix = wdaCacheKeyPrefix("Xcode 26.5", "darwin");
+  assert.equal(prefix, "dd-wda-v2-darwin-Xcode-26.5-xcuitest-");
+  assert.ok(wdaCacheKey("Xcode 26.5", "9.2.1", "darwin").startsWith(prefix));
 });
 
 test("detectXcodeVersion reads the first line and tolerates failure", () => {
@@ -115,6 +126,17 @@ test("detectXcodeVersion reads the first line and tolerates failure", () => {
   assert.equal(
     detectXcodeVersion(() => {
       throw new Error("xcodebuild missing");
+    }),
+    "unknown"
+  );
+});
+
+test("detectXcuitestDriverVersion trims npm's output and tolerates failure", () => {
+  assert.equal(detectXcuitestDriverVersion(() => "9.2.1\n"), "9.2.1");
+  assert.equal(detectXcuitestDriverVersion(() => "  \n"), "unknown");
+  assert.equal(
+    detectXcuitestDriverVersion(() => {
+      throw new Error("registry unreachable");
     }),
     "unknown"
   );
@@ -140,11 +162,12 @@ function recordingDeps(
 }
 
 test("restoreWdaCache reports an exact hit vs a cold cache", async () => {
-  const hitKey = wdaCacheKey("Xcode 26.5");
+  const hitKey = wdaCacheKey("Xcode 26.5", "9.2.1");
   const hit = recordingDeps({ restoreCache: async () => hitKey });
   const r1 = await restoreWdaCache({
     derivedDataPath: "/tmp/wda",
     xcodeVersion: "Xcode 26.5",
+    driverVersion: "9.2.1",
     deps: hit.deps,
   });
   assert.equal(r1.exactHit, true);
@@ -154,9 +177,33 @@ test("restoreWdaCache reports an exact hit vs a cold cache", async () => {
   const r2 = await restoreWdaCache({
     derivedDataPath: "/tmp/wda",
     xcodeVersion: "Xcode 26.5",
+    driverVersion: "9.2.1",
     deps: cold.deps,
   });
   assert.equal(r2.exactHit, false);
+});
+
+test("restoreWdaCache falls back to an older driver's build via restore-keys and reports a non-exact hit", async () => {
+  // A prefix restore (same Xcode, older xcuitest driver) still warms the
+  // incremental build, but must NOT count as exact — the post-run save then
+  // re-caches the healed build under the new driver's key.
+  const staleKey = wdaCacheKey("Xcode 26.5", "9.1.0");
+  let restoreKeysSeen: string[] | undefined;
+  const stale = recordingDeps({
+    restoreCache: async (_paths, _key, restoreKeys) => {
+      restoreKeysSeen = restoreKeys;
+      return staleKey;
+    },
+  });
+  const r = await restoreWdaCache({
+    derivedDataPath: "/tmp/wda",
+    xcodeVersion: "Xcode 26.5",
+    driverVersion: "9.2.1",
+    deps: stale.deps,
+  });
+  assert.equal(r.exactHit, false);
+  assert.equal(r.key, wdaCacheKey("Xcode 26.5", "9.2.1"));
+  assert.deepEqual(restoreKeysSeen, [wdaCacheKeyPrefix("Xcode 26.5")]);
 });
 
 test("restoreWdaCache warns but doesn't throw when the cache service errors", async () => {
@@ -168,6 +215,7 @@ test("restoreWdaCache warns but doesn't throw when the cache service errors", as
   const r = await restoreWdaCache({
     derivedDataPath: "/tmp/wda",
     xcodeVersion: "Xcode 26.5",
+    driverVersion: "9.2.1",
     deps,
   });
   assert.equal(r.exactHit, false);

--- a/src/iosSetup.test.ts
+++ b/src/iosSetup.test.ts
@@ -112,6 +112,23 @@ test("wdaCacheKey folds the Xcode and XCUITest driver versions into a stable key
   );
 });
 
+test("wdaCacheKey sanitizes key segments to the cache-safe charset", () => {
+  // npm versions can carry +build metadata; actions/cache keys want a
+  // conservative charset (and never commas).
+  assert.equal(
+    wdaCacheKey("Xcode 26.5", "9.2.1+build.5", "darwin"),
+    "dd-wda-v2-darwin-Xcode-26.5-xcuitest-9.2.1-build.5"
+  );
+  assert.equal(
+    wdaCacheKey("Xcode 26.5 (17F42), extra", "9.2.1", "darwin"),
+    "dd-wda-v2-darwin-Xcode-26.5-17F42-extra-xcuitest-9.2.1"
+  );
+  assert.equal(
+    wdaCacheKey("Xcode 26.5", "   ", "darwin"),
+    "dd-wda-v2-darwin-Xcode-26.5-xcuitest-unknown"
+  );
+});
+
 test("wdaCacheKeyPrefix is the key minus the driver version, for restore-keys fallback", () => {
   const prefix = wdaCacheKeyPrefix("Xcode 26.5", "darwin");
   assert.equal(prefix, "dd-wda-v2-darwin-Xcode-26.5-xcuitest-");

--- a/src/iosSetup.ts
+++ b/src/iosSetup.ts
@@ -87,13 +87,21 @@ const CACHE_VERSION = "v2";
  * makes a driver release a non-exact (prefix) hit instead: the old build
  * still warms the compile, and the healed build is saved under the new key.
  */
+// actions/cache keys forbid commas and behave best on a conservative charset;
+// npm versions can carry +build metadata and Xcode's version line has spaces.
+// Collapse runs of anything outside [A-Za-z0-9._-] to a single "-".
+function sanitizeKeySegment(value: string): string {
+  return (
+    (value || "unknown").trim().replace(/[^A-Za-z0-9._-]+/g, "-") || "unknown"
+  );
+}
+
 export function wdaCacheKey(
   xcodeVersion: string,
   driverVersion: string,
   platform: NodeJS.Platform = os.platform()
 ): string {
-  const dv = (driverVersion || "unknown").trim().replace(/\s+/g, "-");
-  return `${wdaCacheKeyPrefix(xcodeVersion, platform)}${dv}`;
+  return `${wdaCacheKeyPrefix(xcodeVersion, platform)}${sanitizeKeySegment(driverVersion)}`;
 }
 
 /**
@@ -104,8 +112,7 @@ export function wdaCacheKeyPrefix(
   xcodeVersion: string,
   platform: NodeJS.Platform = os.platform()
 ): string {
-  const xc = (xcodeVersion || "unknown").trim().replace(/\s+/g, "-");
-  return `dd-wda-${CACHE_VERSION}-${platform}-${xc}-xcuitest-`;
+  return `dd-wda-${CACHE_VERSION}-${platform}-${sanitizeKeySegment(xcodeVersion)}-xcuitest-`;
 }
 
 /** Read the Xcode version line (e.g. "Xcode 26.5"); "unknown" if unavailable. */

--- a/src/iosSetup.ts
+++ b/src/iosSetup.ts
@@ -72,21 +72,40 @@ export function shouldCacheWda({
     : { setUp: false, reason: "no ios platform detected in specs" };
 }
 
-// Bump to invalidate every cached WDA build (e.g. after a WDA-shape change in
-// the driver that the version check wouldn't catch).
-const CACHE_VERSION = "v1";
+// Bump to invalidate every cached WDA build (e.g. after a WDA-shape change
+// that neither the Xcode nor the driver version would catch).
+const CACHE_VERSION = "v2";
 
 /**
- * Cache key from the runner OS + Xcode version. Coarse on purpose: the XCUITest
- * driver rebuilds WDA on a version mismatch, so an over-broad hit self-heals —
- * far better than a too-narrow key that never hits.
+ * Exact cache key from the runner OS + Xcode version + XCUITest driver
+ * version. The driver version matters because WDA's source ships inside
+ * appium-xcuitest-driver, which Doc Detective JIT-installs at its latest
+ * version: a cache built for an older driver is stale, and (v1 lesson) a
+ * *stale exact hit* is the worst case — the driver rebuilds WDA nearly from
+ * scratch every run, and the exact hit suppresses the post-run save, so the
+ * cache never heals until the Xcode image moves. Keying on the driver version
+ * makes a driver release a non-exact (prefix) hit instead: the old build
+ * still warms the compile, and the healed build is saved under the new key.
  */
 export function wdaCacheKey(
+  xcodeVersion: string,
+  driverVersion: string,
+  platform: NodeJS.Platform = os.platform()
+): string {
+  const dv = (driverVersion || "unknown").trim().replace(/\s+/g, "-");
+  return `${wdaCacheKeyPrefix(xcodeVersion, platform)}${dv}`;
+}
+
+/**
+ * The exact key minus the driver version — passed as a restore-keys fallback
+ * so an older driver's build still restores for an incremental rebuild.
+ */
+export function wdaCacheKeyPrefix(
   xcodeVersion: string,
   platform: NodeJS.Platform = os.platform()
 ): string {
   const xc = (xcodeVersion || "unknown").trim().replace(/\s+/g, "-");
-  return `dd-wda-${CACHE_VERSION}-${platform}-${xc}`;
+  return `dd-wda-${CACHE_VERSION}-${platform}-${xc}-xcuitest-`;
 }
 
 /** Read the Xcode version line (e.g. "Xcode 26.5"); "unknown" if unavailable. */
@@ -95,6 +114,21 @@ export function detectXcodeVersion(
 ): string {
   try {
     return run("xcodebuild -version").split(/\r?\n/)[0].trim() || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Resolve the appium-xcuitest-driver version Doc Detective will JIT-install
+ * (it installs the latest, so the registry's `latest` is the right predictor).
+ * "unknown" on any failure — the key still works, it's just coarser.
+ */
+export function detectXcuitestDriverVersion(
+  run: (command: string) => string = (c) => execSync(c).toString()
+): string {
+  try {
+    return run("npm view appium-xcuitest-driver version").trim() || "unknown";
   } catch {
     return "unknown";
   }
@@ -120,20 +154,27 @@ export interface WdaCacheDeps {
 export async function restoreWdaCache({
   derivedDataPath,
   xcodeVersion,
+  driverVersion,
   deps,
 }: {
   derivedDataPath: string;
   xcodeVersion: string;
+  driverVersion: string;
   deps: WdaCacheDeps;
 }): Promise<{ key: string; exactHit: boolean }> {
-  const key = wdaCacheKey(xcodeVersion);
+  const key = wdaCacheKey(xcodeVersion, driverVersion);
+  const prefix = wdaCacheKeyPrefix(xcodeVersion);
   try {
-    const restoredKey = await deps.restoreCache([derivedDataPath], key);
+    const restoredKey = await deps.restoreCache([derivedDataPath], key, [
+      prefix,
+    ]);
     const exactHit = restoredKey === key;
     deps.info(
       exactHit
         ? `Restored the WebDriverAgent build cache (${key}); the WDA build will be incremental.`
-        : `No WebDriverAgent build cache yet (key ${key}); the first run compiles WDA (~10 min) and caches it.`
+        : restoredKey
+          ? `Restored an older WebDriverAgent build (${restoredKey}); the build warms from it and is re-cached as ${key}.`
+          : `No WebDriverAgent build cache yet (key ${key}); the first run compiles WDA (~10 min) and caches it.`
     );
     return { key, exactHit };
   } catch (error) {


### PR DESCRIPTION
## Summary

Follow-up to #73. The v1 WDA cache key (`dd-wda-v1-<os>-<xcode>`) omitted the XCUITest driver version, but WDA's source ships **inside** `appium-xcuitest-driver`, which Doc Detective JIT-installs at latest. Once the driver moves past the cached build:

- every run restores stale derivedData → near-full ~10–25 min xcodebuild rebuild, and
- the restore is an **exact hit**, so `saveWdaCache` skips the save (GitHub cache keys are immutable) — the cache never heals until the runner's Xcode image bumps.

Observed on doc-detective PR CI (doc-detective/doc-detective run 28808626492, `apps-ios (macos-latest)`): cache hit on `dd-wda-v1-darwin-Xcode-16.4`, yet the first `POST /session` still ran the full 15-minute ceiling and aborted. Runner-side sensitivity fix: doc-detective/doc-detective#526.

## Change

- `CACHE_VERSION` → **v2**; exact key is now `dd-wda-v2-<os>-<xcode>-xcuitest-<driver-version>` with the driver version resolved via `npm view appium-xcuitest-driver version` (`unknown` fallback on registry failure, mirroring `detectXcodeVersion`).
- `restoreWdaCache` passes a **restore-keys prefix** (`dd-wda-v2-<os>-<xcode>-xcuitest-`): a driver release lands as a non-exact prefix hit — the older build still warms the incremental compile, and the post-run save re-caches the healed build under the new driver's key. The stale-exact-hit trap is gone by construction.
- Distinct log lines for exact hit / prefix hit / cold cache.

## Tests

`npm test` (26 passing) — new cases for the v2 key shape, the prefix helper, `detectXcuitestDriverVersion` fallback, and the prefix-hit restore reporting non-exact with the right restore-keys. `npm run typecheck` clean; `dist/` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)